### PR TITLE
Fix missing latitude and longitude for Bodfish and South Lake

### DIFF
--- a/restaurants.yml
+++ b/restaurants.yml
@@ -191,7 +191,7 @@
     '@type': GeoCoordinates
     longitude: -118.425951
     latitude: 35.755295
-- name: Paradise Cove Lodge
+- name: Paradise Cove Lodge (Steak House)
   identifier: f779f9cd-ce71-43d7-974e-6d30dd2e7af2
   "@context": https://schema.org
   "@type": Restaurant

--- a/towns.yml
+++ b/towns.yml
@@ -48,6 +48,8 @@
   identifier: bodfish
   "@context": https://schema.org
   "@type": City
+  latitude: 35.596626
+  longitude: -118.491558
   geo:
     "@type": GeoCoordinates
     latitude: 35.596626
@@ -68,6 +70,8 @@
   identifier: south-lake
   "@context": https://schema.org
   "@type": City
+  latitude: 35.641459
+  longitude: -118.370365
   geo:
     "@type": GeoCoordinates
     latitude: 35.641459


### PR DESCRIPTION
Also adds "(Steak House)" for Paradise Cove Lodge in restaurants